### PR TITLE
[codex] show oversized upload toast

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ import DropboxOauthPanel from "./components/DropboxOauthPanel";
 const DROPBOX_AUTH_DOMAIN = "https://roamjs.com";
 const DROPBOX_UPLOAD_URL = "https://content.dropboxapi.com/2/files/upload";
 const DROPBOX_LOADING_TEXT = "";
+const DROPBOX_UPLOAD_LIMIT_MB = 150;
+const DROPBOX_UPLOAD_LIMIT_BYTES = DROPBOX_UPLOAD_LIMIT_MB * 1024 * 1024;
 
 const mimeLookup = (path: string) => {
   if (!path || typeof path !== "string") {
@@ -267,6 +269,20 @@ export default runExtension(async (args) => {
       e.stopPropagation();
       e.stopImmediatePropagation();
       e.preventDefault();
+
+      if (fileToUpload.size > DROPBOX_UPLOAD_LIMIT_BYTES) {
+        const fileName = fileToUpload.name || "This file";
+        renderToast({
+          id: "dropbox-upload-too-large",
+          intent: Intent.DANGER,
+          timeout: 8000,
+          content:
+            `${fileName} is too large to upload to Dropbox. ` +
+            `This uploader currently supports files up to ${DROPBOX_UPLOAD_LIMIT_MB} MB.`,
+        });
+        hideDropBars();
+        return;
+      }
 
       getLoadingUid().then((uid) => {
         const removeLoading = renderUploadLoading(uid);


### PR DESCRIPTION
## Summary

Adds a client-side 150 MB size guard before sending files to Dropbox. Oversized files now show a dedicated danger toast explaining that this uploader currently supports files up to 150 MB.

## Why

The current uploader uses Dropbox's single `/2/files/upload` endpoint, which rejects payloads larger than 150 MB. Without a local check, users wait for Dropbox to fail and see the generic upload failure message.

## Impact

Users get immediate, specific feedback when a file is too large. The guard also avoids reading oversized files into memory before the request.

## Validation

- `npm run build:roam` passed with `src built with 0 errors`.
- `npx tsc --noEmit -p tsconfig.json` still fails on existing `src/mimeTypes.ts` undefined checks unrelated to this change.